### PR TITLE
Add ESLint rule "endOfLine": "auto" for Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
   },
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off"
+    "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+    "prettier/prettier": ["error", { endOfLine: "auto" }]
   },
   overrides: [{
     files: ["**/__tests__/*.{j,t}s?(x)", "./src/**/*.spec.{j,t}s?(x)"],


### PR DESCRIPTION
This allows Windows developers to use CRLF instead the LF by default.